### PR TITLE
Fix to run the CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   pull_request:
     types: [ opened, synchronize, reopened ]
-    branches: [ main ]
+    branches: [ 2/edge ]
     paths-ignore:
       - '**.md'
       - '**.rst'


### PR DESCRIPTION
prometheus-opensearch-dashboards-exporter follows the convention of opensearch-dashboards-operator and use the 2/edge branch instead of main.